### PR TITLE
Fix JS typo with french language

### DIFF
--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -13,6 +13,6 @@ $lang['userpage']        = 'Page utilisateur';
 $lang['user_tools'] = 'Outils pour utilisateurs';
 $lang['site_tools'] = 'Outils du site';
 $lang['page_tools'] = 'Outils de la page';
-$lang['skip_to_content'] = 'Aller au contenu';)
+$lang['skip_to_content'] = 'Aller au contenu';
 
 //Setup VIM: ex: et ts=2 :


### PR DESCRIPTION
Fixed typo that caused HTTP 500 errors in /lib/exe/js.php in french language configuration of dokuwiki (lang=fr)
