### PR TITLE
Avoid orphaned headings

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -66,6 +66,9 @@ caption,
 legend {
   margin: 10px 0 10px;
   clear: both;
+  page-break-before: auto;
+  page-break-inside: avoid;
+  page-break-after: avoid;
 }
 p, table, pre, ul, ol {
   margin: 0 0 10px;


### PR DESCRIPTION
Sometimes headings would end a page and following text would be separated on another page. This settings fixes it.